### PR TITLE
Workaround to disable native animation in Touchable Opacity 

### DIFF
--- a/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/Libraries/Components/Touchable/TouchableOpacity.js
@@ -198,7 +198,8 @@ class TouchableOpacity extends React.Component<Props, State> {
       toValue,
       duration,
       easing: Easing.inOut(Easing.quad),
-      useNativeDriver: true,
+      /*Workaround:Disable navtive animation,until feature support available*/
+      useNativeDriver: false,
     }).start();
   }
 


### PR DESCRIPTION
Opacity of Touchable Opacity component is controlled in an Animated.View , which is configured with useNativeDriver as 'true'
Setting this configuration to false for time-being , to control the opacity via JS animation.