### PR TITLE
Fallback to JS animation when useNativeDriver is enabled

### DIFF
--- a/Libraries/Animated/NativeAnimatedHelper.js
+++ b/Libraries/Animated/NativeAnimatedHelper.js
@@ -364,7 +364,9 @@ function shouldUseNativeDriver(
     return false;
   }
 
-  return config.useNativeDriver || false;
+  //Animated 'useNativeDriver' not supported,so fallback to JS-based animation
+  //return config.useNativeDriver || false;
+  return false;
 }
 
 function transformDataType(value: number | string): number | string {

--- a/Libraries/Animated/NativeAnimatedHelper.js
+++ b/Libraries/Animated/NativeAnimatedHelper.js
@@ -364,7 +364,7 @@ function shouldUseNativeDriver(
     return false;
   }
 
-  //Animated 'useNativeDriver' not supported,so fallback to JS-based animation
+  //Animated 'useNativeDriver' is not yet supported in RNS,so fallback to JS-based animation
   //return config.useNativeDriver || false;
   return false;
 }


### PR DESCRIPTION
https://github.com/nagra-opentv/react-native-skia project uses  nagra-opentv/react-native-tvos.
The react-native-skia currently does not support Native Animation. 
So to avoid changes in app to work on react-native-skia, we fallback to JS animation when app enable useNativeDriver

=========
To be reverted, 
a) When native animation is supported in react-native-skia
b) If this repo is been used by other projects which support native animation