### PR TITLE
Backported setNativeProps support for Fabric.

### DIFF
--- a/Libraries/Renderer/implementations/ReactFabric-dev.js
+++ b/Libraries/Renderer/implementations/ReactFabric-dev.js
@@ -3824,7 +3824,23 @@ var ReactFabricHostComponent = /*#__PURE__*/ (function() {
 
   _proto.setNativeProps = function setNativeProps(nativeProps) {
     {
-      error("Warning: setNativeProps is not currently supported in Fabric");
+      error("Warning: setNativeProps is deprecated. Please update props using React state instead");
+      const updatePayload = create(nativeProps, this.viewConfig.validAttributes);
+
+      const {stateNode} = this._internalInstanceHandle;
+      if (stateNode != null && updatePayload != null) {
+        if (this._internalInstanceHandle) {
+          nativeFabricUIManager.setNativeProps(
+          this._internalInstanceHandle.stateNode.node,
+          updatePayload
+          );
+        } else {
+          error(
+            "setNativeProps was called with a ref that isn't a " +
+            "native component. Use React.forwardRef to get access to the underlying native component"
+          );
+        }
+      }
     }
 
     return;

--- a/ReactCommon/react/renderer/core/ShadowNodeFamily.h
+++ b/ReactCommon/react/renderer/core/ShadowNodeFamily.h
@@ -85,6 +85,13 @@ class ShadowNodeFamily {
   void dispatchRawState(StateUpdate &&stateUpdate, EventPriority priority)
       const;
 
+  /*
+   * Holds currently applied native props. `nullptr` if setNativeProps API is
+   * not used. It is used to backport setNativeProps API from the old
+   * architecture and will be removed in the future.
+   */
+  mutable std::unique_ptr<folly::dynamic> nativeProps_DEPRECATED;
+
  private:
   friend ShadowNode;
   friend ShadowNodeFamilyFragment;

--- a/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -370,6 +370,17 @@ void Scheduler::uiManagerDidDispatchCommand(
   }
 }
 
+void Scheduler::setNativeProps_DEPRECATED(
+    const ShadowNode::Shared &shadowNode,
+    Props::Shared props) {
+  SystraceSection s("Scheduler::setNativeProps_DEPRECATED");
+
+  if (delegate_ != nullptr) {
+    auto shadowView = ShadowView(*shadowNode);
+    delegate_->setNativeProps_DEPRECATED(shadowView, std::move(props));
+  }
+}
+
 /*
  * Set JS responder for a view
  */

--- a/ReactCommon/react/renderer/scheduler/Scheduler.h
+++ b/ReactCommon/react/renderer/scheduler/Scheduler.h
@@ -111,6 +111,9 @@ class Scheduler final : public UIManagerDelegate {
       const ShadowNode::Shared &shadowNode,
       std::string const &commandName,
       folly::dynamic const args) override;
+  void setNativeProps_DEPRECATED(
+      const ShadowNode::Shared &shadowNode,
+      Props::Shared props) override;
   void uiManagerDidSetJSResponder(
       SurfaceId surfaceId,
       const ShadowNode::Shared &shadowView,

--- a/ReactCommon/react/renderer/scheduler/SchedulerDelegate.h
+++ b/ReactCommon/react/renderer/scheduler/SchedulerDelegate.h
@@ -41,6 +41,10 @@ class SchedulerDelegate {
       std::string const &commandName,
       folly::dynamic const args) = 0;
 
+  virtual void setNativeProps_DEPRECATED(
+      const ShadowView &shadowView,
+      Props::Shared props) = 0;
+
   /*
    * Set JS responder for a view
    */

--- a/ReactCommon/react/renderer/uimanager/UIManager.h
+++ b/ReactCommon/react/renderer/uimanager/UIManager.h
@@ -138,6 +138,10 @@ class UIManager final : public ShadowTreeDelegate {
       std::string const &commandName,
       folly::dynamic const args) const;
 
+  void setNativeProps_DEPRECATED(
+      ShadowNode::Shared const &shadowNode,
+      RawProps const &rawProps) const;
+
   /**
    * Configure a LayoutAnimation to happen on the next commit.
    * This API configures a global LayoutAnimation starting from the root node.

--- a/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -543,6 +543,25 @@ jsi::Value UIManagerBinding::get(
   }
 
   // Legacy API
+ if (methodName == "setNativeProps") {
+    return jsi::Function::createFromHostFunction(
+        runtime,
+        name,
+        2,
+        [uiManager](
+            jsi::Runtime &runtime,
+            const jsi::Value &,
+            const jsi::Value *arguments,
+            size_t) -> jsi::Value {
+          uiManager->setNativeProps_DEPRECATED(
+              shadowNodeFromValue(runtime, arguments[0]),
+              RawProps(runtime, arguments[1]));
+
+          return jsi::Value::undefined();
+        });
+  }
+
+  // Legacy API
   if (methodName == "measureLayout") {
     return jsi::Function::createFromHostFunction(
         runtime,

--- a/ReactCommon/react/renderer/uimanager/UIManagerDelegate.h
+++ b/ReactCommon/react/renderer/uimanager/UIManagerDelegate.h
@@ -43,6 +43,15 @@ class UIManagerDelegate {
       folly::dynamic const args) = 0;
 
   /*
+   * Called when UIManager wants directly manipulate view on the mounting layer.
+   * This is a backport of setNativeProps from the old architecture and will be
+   * removed in the future.
+   */
+  virtual void setNativeProps_DEPRECATED(
+      const ShadowNode::Shared &shadowNode,
+      Props::Shared props) = 0;
+
+  /*
    * Set JS responder for a view
    */
   virtual void uiManagerDidSetJSResponder(


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

setNativeProps was not supported in fabric and recently it was added as deprecated API in latest version. 
This PR will bnackport the deprecated API to 0.64 TVOS version.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

## Test Plan

Verified with test app https://snack.expo.dev/@shyamsrj/setnativeprops-ex1
