### PR TITLE
Fix build issue for SafeAreViewComponentDescriptor

### DIFF
--- a/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewComponentDescriptor.h
+++ b/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewComponentDescriptor.h
@@ -31,7 +31,7 @@ class SafeAreaViewComponentDescriptor final
             safeAreaViewShadowNode);
 
     auto state =
-        std::static_pointer_cast<const SafeAreaViewShadowNode::ConcreteState>(
+        std::static_pointer_cast<const SafeAreaViewShadowNode::ConcreteStateT>(
             shadowNode->getState());
     auto stateData = state->getData();
 

--- a/ReactCommon/react/renderer/uimanager/UIManager.cpp
+++ b/ReactCommon/react/renderer/uimanager/UIManager.cpp
@@ -98,11 +98,11 @@ SharedShadowNode UIManager::cloneNode(
     if (family.nativeProps_DEPRECATED != nullptr) {
       family.nativeProps_DEPRECATED =
           std::make_unique<folly::dynamic>(mergeDynamicProps(
-              (folly::dynamic)*rawProps, *family.nativeProps_DEPRECATED));
+              *family.nativeProps_DEPRECATED, (folly::dynamic)*rawProps));
 
       props = componentDescriptor.cloneProps(
           shadowNode->getProps(),
-          mergeRawProps(*family.nativeProps_DEPRECATED, *rawProps));
+          RawProps(*family.nativeProps_DEPRECATED));
     } else {
       props = componentDescriptor.cloneProps(
           shadowNode->getProps(), *rawProps);


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

In commit 2c769b9cac9cb7bc30c4feba73024beb0e7d389f, we changed few code for supporting GCC toolchain.
As part of this commit we modified only those related files which was supported at that time.
Now added similar fix for SafeAreaview component

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

## Test Plan

This just fixes BUILD issue when we include SafeAreaComponent core files in RNS 
